### PR TITLE
BAH-2759 | update the branch for build pipeline

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -2,7 +2,7 @@ name: Build and Publish bahmni-mart Image and Helm Chart
 on:
   push:
     branches: 
-      - main
+      - master
 
 jobs:
   


### PR DESCRIPTION
The Bahmni-Mart latest image is not getting deployed to Docker-hub and gh-pages.

## Jira
-----------
https://bahmni.atlassian.net/browse/BAH-2759