### PR TITLE
Rahul | Fix. Default Python switched to 3.8 on Ubuntu runner

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -2,9 +2,7 @@ name: Create Release
 
 on:
   push:
-    branches: 
-      - master 
-      - workflow-test
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -2,7 +2,9 @@ name: Create Release
 
 on:
   push:
-    branches: [ master ]
+    branches: 
+      - master 
+      - workflow-test
 
 jobs:
   build:
@@ -11,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7]
+        python-version: [3.8]
 
     services:
       postgres:


### PR DESCRIPTION
Currently, Python 2.7 is set by default on Ubuntu 20.04. Python 2 was sunsetted on Jan 1 2020 and this version is not supported anymore. In scope of this PR we set the default Python to 3.8 on Ubuntu 20.04.

If we still need to use Python 2.x on Ubuntu runner, we will have to switch to Python to 2.7 using [actions/setup-python](https://github.com/actions/setup-python) and [UsePython](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-python-version?view=azure-devops) tasks.

<img width="1359" alt="Screenshot 2023-07-07 at 12 05 34 PM" src="https://github.com/Bahmni/bahmni-mart/assets/121226043/0ed214d8-e8ca-49d9-8af2-64089efb87ac">