### PR TITLE
BAH-4867 | Mart DB table - visit_diagnosis data not populating for diagnosis added from new clinical

### DIFF
--- a/src/main/resources/groupedJobs/diagnosesAndConditions.json
+++ b/src/main/resources/groupedJobs/diagnosesAndConditions.json
@@ -14,6 +14,12 @@
       "type": "customSql",
       "readerSql": "SELECT condition_id, previous_version, patient_id, clinical_status, coalesce(condition_non_coded, cv.concept_full_name) AS condition_name, CASE WHEN condition_non_coded IS NULL THEN TRUE ELSE FALSE END AS is_coded_condition_name, onset_date, additional_detail, end_date, concat_ws(' ', ifnull(pn.given_name, ''), ifnull(pn.family_name, '')) AS creator_name, conditions.date_created FROM conditions INNER JOIN concept_view cv ON cv.concept_id = conditions.condition_coded AND conditions.voided = 0 AND cv.retired = 0 INNER JOIN users ON users.user_id = conditions.creator INNER JOIN person_name pn ON pn.person_id = users.person_id",
       "tableName": "conditions_default"
+    },
+    {
+      "name": "Encounter Diagnoses",
+      "type": "customSql",
+      "readerSql": "SELECT ed.diagnosis_id, ed.uuid, ed.patient_id, ed.encounter_id, e.visit_id, coalesce(ed.diagnosis_non_coded, cv.concept_full_name) AS coded_diagnosis, ed.diagnosis_non_coded AS non_coded_diagnosis, CASE WHEN ed.diagnosis_non_coded IS NULL THEN TRUE ELSE FALSE END AS is_coded_diagnosis, ed.certainty AS diagnosis_certainty, ed.dx_rank AS diagnosis_order, ed.date_created, concat_ws(' ', ifnull(pn.given_name, ''), ifnull(pn.family_name, '')) AS creator_name FROM encounter_diagnosis ed INNER JOIN encounter e ON e.encounter_id = ed.encounter_id LEFT JOIN concept_view cv ON cv.concept_id = ed.diagnosis_coded AND cv.retired = 0 INNER JOIN users u ON u.user_id = ed.creator INNER JOIN person_name pn ON pn.person_id = u.person_id WHERE ed.voided = 0",
+      "tableName": "encounter_diagnosis_default"
     }
   ]
 }

--- a/src/main/resources/viewSql/patientDiagnosisConditionView.sql
+++ b/src/main/resources/viewSql/patientDiagnosisConditionView.sql
@@ -1,3 +1,37 @@
+WITH all_diagnoses AS (
+  SELECT
+    patient_id,
+    encounter_id,
+    coded_diagnosis,
+    non_coded_diagnosis,
+    diagnosis_certainty,
+    diagnosis_order,
+    obs_datetime AS diagnosis_date,
+    'legacy' AS diagnosis_source
+  FROM visit_diagnoses
+
+  UNION ALL
+
+  SELECT
+    patient_id,
+    encounter_id,
+    coded_diagnosis,
+    non_coded_diagnosis,
+    CASE diagnosis_certainty
+      WHEN 'CONFIRMED' THEN 'Confirmed'
+      WHEN 'PROVISIONAL' THEN 'Provisional'
+      ELSE diagnosis_certainty
+    END AS diagnosis_certainty,
+    CASE diagnosis_order
+      WHEN 1 THEN 'Primary'
+      WHEN 2 THEN 'Secondary'
+      ELSE diagnosis_order::text
+    END AS diagnosis_order,
+    date_created AS diagnosis_date,
+    'new_ui' AS diagnosis_source
+  FROM encounter_diagnosis_default
+)
+
 SELECT
   pd.person_id AS patient_id,
   pd.gender,
@@ -14,21 +48,15 @@ SELECT
   c.end_date AS condition_end_date,
   c.date_created AS condition_date_created,
   c.creator_name AS creator,
-  vd.encounter_id,
-  vd.coded_diagnosis,
-  vd.non_coded_diagnosis,
-  vd.diagnosis_certainty,
-  vd.diagnosis_order,
-  vd.obs_datetime,
-  ed.encounter_id AS encounter_diagnosis_encounter_id,
-  ed.coded_diagnosis AS encounter_coded_diagnosis,
-  ed.non_coded_diagnosis AS encounter_non_coded_diagnosis,
-  ed.diagnosis_certainty AS encounter_diagnosis_certainty,
-  ed.diagnosis_order AS encounter_diagnosis_order,
-  ed.date_created AS encounter_diagnosis_date_created
+  d.encounter_id,
+  d.coded_diagnosis,
+  d.non_coded_diagnosis,
+  d.diagnosis_certainty,
+  d.diagnosis_order,
+  d.diagnosis_date,
+  d.diagnosis_source
 
 FROM person_details_default pd
   LEFT JOIN person_attributes pa ON pa.person_id = pd.person_id
   LEFT JOIN conditions_default c ON c.patient_id = pd.person_id
-  LEFT JOIN visit_diagnoses vd ON vd.patient_id = pd.person_id
-  LEFT JOIN encounter_diagnosis_default ed ON ed.patient_id = pd.person_id
+  LEFT JOIN all_diagnoses d ON d.patient_id = pd.person_id

--- a/src/main/resources/viewSql/patientDiagnosisConditionView.sql
+++ b/src/main/resources/viewSql/patientDiagnosisConditionView.sql
@@ -19,9 +19,16 @@ SELECT
   vd.non_coded_diagnosis,
   vd.diagnosis_certainty,
   vd.diagnosis_order,
-  vd.obs_datetime
+  vd.obs_datetime,
+  ed.encounter_id AS encounter_diagnosis_encounter_id,
+  ed.coded_diagnosis AS encounter_coded_diagnosis,
+  ed.non_coded_diagnosis AS encounter_non_coded_diagnosis,
+  ed.diagnosis_certainty AS encounter_diagnosis_certainty,
+  ed.diagnosis_order AS encounter_diagnosis_order,
+  ed.date_created AS encounter_diagnosis_date_created
 
 FROM person_details_default pd
   LEFT JOIN person_attributes pa ON pa.person_id = pd.person_id
   LEFT JOIN conditions_default c ON c.patient_id = pd.person_id
   LEFT JOIN visit_diagnoses vd ON vd.patient_id = pd.person_id
+  LEFT JOIN encounter_diagnosis_default ed ON ed.patient_id = pd.person_id


### PR DESCRIPTION
Diagnosis added from legacy clinical adds rows to visit_diagnosis table but diagnosis added through new UI does not add rows to  visit_diagnosis. 