### PR TITLE
BAH-4709|Fix. suppressions.xml path resolution for Gradle 8.5+ worker…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ checkstyle {
     project.ext.sevntuChecksVersion = '1.27.0'
     ignoreFailures = false
     configFile = file("src/main/resources/checkStyle.xml")
+    configDirectory = file("src/main/resources")
 
     checkstyleMain {
         source = sourceSets.main.allSource

--- a/src/main/resources/checkStyle.xml
+++ b/src/main/resources/checkStyle.xml
@@ -11,7 +11,7 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="SuppressionFilter">
-        <property name="file" value="src/main/resources/suppressions.xml"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
         <property name="optional" value="true"/>
     </module>
 


### PR DESCRIPTION
Gradle 8.5 introduced isolated worker processes with different working directories
than the project root. Hardcoded relative paths like 'src/main/resources/suppressions.xml'
no longer resolve correctly, causing suppressions to silently fail when optional=true.

Fix: Use Gradle's official \${config_loc} variable which is pre-computed and injected
by the Checkstyle plugin before the worker process starts. This ensures suppressions.xml
always resolves correctly regardless of working directory.

Changes:
- Add configDirectory = file('src/main/resources') in build.gradle checkstyle block
- Update checkStyle.xml to use \${config_loc}/suppressions.xml
